### PR TITLE
Bug Fixed

### DIFF
--- a/src/linovelib2epub/linovel.py
+++ b/src/linovelib2epub/linovel.py
@@ -47,9 +47,8 @@ class EpubWriter:
         else:
             for volume in novel.volumes:
                 # if volume image folder is not empty, then use the first image as the cover
-                if volume["volume_img_folder"]:
-                    cover_file = os.listdir(f'{self.epub_settings["image_download_folder"]}/{volume["volume_img_folder"]}')[0]
-                    cover_file = f'{self.epub_settings["image_download_folder"]}/{volume["volume_img_folder"]}/{cover_file}'
+                if volume["volume_cover"]:
+                    cover_file = f'{self.epub_settings["image_download_folder"]}/{volume["volume_img_folder"]}/{volume["volume_cover"]}'
                 self._write_epub(f'{book_title}_{volume["title"]}', author, volume, cover_file)
 
         # tips: show output file folder
@@ -193,7 +192,7 @@ class EpubWriter:
 
     def _add_images(self, book, images_folder, volume_img_folder):
 
-        def func(image_file):
+        def add_image(image_file):
             if not ((".jpg" or ".png" or ".webp" or ".jpeg" or ".bmp" or "gif") in str(image_file)):
                 return
             try:
@@ -216,12 +215,12 @@ class EpubWriter:
                 # grab all images under all [volume_img_folder]
                 for volume_img_folder in os.listdir(images_folder):
                     for image_file in os.listdir(f'{images_folder}/{volume_img_folder}'):
-                        func(image_file)
+                        add_image(image_file)
             else:
                 # only grab images under current [volume_img_folder]
                 if volume_img_folder != "":
                     for image_file in os.listdir(f'{images_folder}/{volume_img_folder}'):
-                        func(image_file)
+                        add_image(image_file)
 
     def _get_output_folder(self):
         if self.epub_settings['divide_volume']:

--- a/src/linovelib2epub/linovel.py
+++ b/src/linovelib2epub/linovel.py
@@ -101,7 +101,7 @@ class EpubWriter:
                 # volume_title as h1
                 html_volume_title = "<h1>" + volume_title + "</h1>"
                 write_content += html_volume_title
-                book.toc.append([epub.Section(volume_title), []])
+                book.toc.append([epub.Link(f"{file_index+1}.xhtml", volume_title, str(uuid.uuid4())), []])
 
             chapter_index += 1
             for chapter in volume['chapters']:
@@ -177,7 +177,12 @@ class EpubWriter:
         # FINAL WRITE
         # if divide volume, create a folder named title, or leave folder as "“
         out_folder = self._get_output_folder()
-        epub.write_epub(sanitize_pathname(out_folder) + "/" + sanitize_pathname(title) + '.epub', book)
+        if not self.epub_settings["divide_volume"]:
+            prefix = ""
+        else:
+            prefix = "%02d." % volume['vid']
+
+        epub.write_epub(sanitize_pathname(out_folder) + "/" + prefix + sanitize_pathname(title) + '.epub', book)
 
     @staticmethod
     def _set_page_style(book, custom_style_chapter, default_style_chapter, page):

--- a/src/linovelib2epub/models.py
+++ b/src/linovelib2epub/models.py
@@ -14,6 +14,7 @@ class LightNovelVolume:
     vid: Union[int, str]
     title: str = ''
     chapters: list = field(default_factory=list)
+    volume_img_folder: str = ''
 
     def add_chapter(self, cid: Union[int, str], title: str = '', content: str = ''):
         new_chapter = {
@@ -72,11 +73,12 @@ class LightNovel:
                 image_set.add(value)
         return image_set
 
-    def add_volume(self, vid: Union[int, str], title: str = '', chapters: List = None):
+    def add_volume(self, vid: Union[int, str], title: str = '', chapters: List = None, volume_img_folder: str = ''):
         new_volume = {
             'vid': vid,
             'title': title,
-            'chapters': chapters if chapters else []
+            'chapters': chapters if chapters else [],
+            'volume_img_folder': volume_img_folder,
         }
         self.volumes.append(new_volume)
 

--- a/src/linovelib2epub/models.py
+++ b/src/linovelib2epub/models.py
@@ -14,7 +14,15 @@ class LightNovelVolume:
     vid: Union[int, str]
     title: str = ''
     chapters: list = field(default_factory=list)
+
+    # volume_img_folder is used to extract images in specific volume when "divide_volume=True"
     volume_img_folder: str = ''
+    # volume_cover is used as the cover image in specific volume when "divide_volume=True"
+    volume_cover: str = ''
+
+    # example: https://img.linovelib.com/0/682/117077/50675.jpg
+    # volume_img_folder = "117077"
+    # volume_cover = "50677.jpg"
 
     def add_chapter(self, cid: Union[int, str], title: str = '', content: str = ''):
         new_chapter = {
@@ -73,12 +81,13 @@ class LightNovel:
                 image_set.add(value)
         return image_set
 
-    def add_volume(self, vid: Union[int, str], title: str = '', chapters: List = None, volume_img_folder: str = ''):
+    def add_volume(self, vid: Union[int, str], title: str = '', chapters: List = None, volume_img_folder: str = '', volume_cover: str = ''):
         new_volume = {
             'vid': vid,
             'title': title,
             'chapters': chapters if chapters else [],
             'volume_img_folder': volume_img_folder,
+            'volume_cover': volume_cover,
         }
         self.volumes.append(new_volume)
 

--- a/src/linovelib2epub/spider/base_spider.py
+++ b/src/linovelib2epub/spider/base_spider.py
@@ -34,14 +34,11 @@ class BaseNovelWebsiteSpider(ABC):
     def fetch(self) -> LightNovel:
         raise NotImplementedError()
 
-    def request_headers(self, referer: str = '', random_ua: bool = True) -> dict:
-        default_ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36'
-        default_referer = 'https://w.linovelib.com'
-        headers = {
-            'referer': referer if referer else default_referer,
-            'user-agent': self.spider_settings['random_useragent'] if random_ua else default_ua
-        }
-        return headers
+    def request_headers(self) -> dict:
+        return {}
+
+    def get_image_filename(self, url) -> str:
+        return url.rsplit('/', 1)[1]
 
     def download_images_by_multiprocessing(self, urls: Iterable = None) -> None:
         if urls is None:

--- a/src/linovelib2epub/spider/base_spider.py
+++ b/src/linovelib2epub/spider/base_spider.py
@@ -59,7 +59,7 @@ class BaseNovelWebsiteSpider(ABC):
             self.logger.info(f'Retry image links: {sorted_error_links}')
             error_links = process_pool.map(self._download_image_legacy, sorted_error_links)
 
-        # downloading image: https://img.linovelib.com/0/682/117082/50748.jpg to [folder]/0-682-117082-50748.jpg
+        # downloading image: https://img.linovelib.com/0/682/117082/50748.jpg to [image_download_folder]/[117082]/50748.jpg
         # re-check image download result:
         # - happy result: urls_set - self.image_download_folder == 0
         # - ? result: urls_set - self.image_download_folder < 0 , maybe you put some other images in this folder.

--- a/src/linovelib2epub/spider/base_spider.py
+++ b/src/linovelib2epub/spider/base_spider.py
@@ -43,9 +43,6 @@ class BaseNovelWebsiteSpider(ABC):
         }
         return headers
 
-    def get_image_filename(self, url) -> str:
-        return url.rsplit('/', 1)[1]
-
     def download_images_by_multiprocessing(self, urls: Iterable = None) -> None:
         if urls is None:
             urls = set()
@@ -67,7 +64,8 @@ class BaseNovelWebsiteSpider(ABC):
         # - happy result: urls_set - self.image_download_folder == 0
         # - ? result: urls_set - self.image_download_folder < 0 , maybe you put some other images in this folder.
         # - bad result: urls_set - self.image_download_folder > 0
-        download_image_miss_quota = len(urls) - len(os.listdir(self.spider_settings['image_download_folder']))
+
+        download_image_miss_quota = len(urls) - sum([len(files) for root, dirs, files in os.walk(self.spider_settings['image_download_folder'])])
         self.logger.info(f'download_image_miss_quota: {download_image_miss_quota}. Quota <=0 is ok.')
         if download_image_miss_quota <= 0:
             self.logger.info('The result of downloading pictures is perfect.')
@@ -86,6 +84,8 @@ class BaseNovelWebsiteSpider(ABC):
 
         filename = self.get_image_filename(url)
         save_path = f"{self.spider_settings['image_download_folder']}/{filename}"
+        if not os.path.exists(os.path.dirname(save_path)):
+            os.makedirs(os.path.dirname(save_path))
 
         filename_path = Path(save_path)
         if filename_path.exists():
@@ -154,6 +154,8 @@ class BaseNovelWebsiteSpider(ABC):
 
         filename = self.get_image_filename(url)
         save_path = f"{self.spider_settings['image_download_folder']}/{filename}"
+        if not os.path.exists(os.path.dirname(save_path)):
+            os.makedirs(os.path.dirname(save_path))
 
         filename_path = Path(save_path)
         if filename_path.exists():

--- a/src/linovelib2epub/spider/linovelib_mobile_spider.py
+++ b/src/linovelib2epub/spider/linovelib_mobile_spider.py
@@ -253,17 +253,18 @@ class LinovelibMobileSpider(BaseNovelWebsiteSpider):
                         content=chapter.content
                     )
 
-                # store [volume_img_folder] in volume dict
-                # [volume_img_folder] is used to extract images in specific volume when "divide_volume=True"
+                # store [volume_img_folder] and [volume_cover] in volume dict
                 if illustration_dict[volume['vid']]:
-                    sample_url = illustration_dict[volume['vid']][0]
-                    new_volume.volume_img_folder = sample_url.split("/")[-2]
+                    cover_image_url = illustration_dict[volume['vid']][0]
+                    path = self.get_image_filename(cover_image_url)
+                    new_volume.volume_img_folder, new_volume.volume_cover = path.split("/")
 
                 new_novel.add_volume(
                     vid=new_volume.vid,
                     title=new_volume.title,
                     chapters=new_volume.chapters,
-                    volume_img_folder=new_volume.volume_img_folder
+                    volume_img_folder=new_volume.volume_img_folder,
+                    volume_cover=new_volume.volume_cover
                 )
 
             new_novel.set_illustration_dict(illustration_dict)


### PR DESCRIPTION
1. 爬取图片的headers增添了'referer'
2. 第一章（插圖）图片为lazyload，修改获取url为"data-src"属性
3. 增添了去除第一章（插圖）多余图片的功能（很多图片是后续章节的黑白插图，没必要再次出现在第一章的彩图中）
4. 修复了divide_volume=True时，所有每个epub都会存有所有图片的bug：在LightNovelVolume和volume dict中添加了一个volume_img_folder属性，将图片保存在`[image_download_folder]/[volume_img_folder]/[filename]`的路径
5. 修改了book.toc的生成方法
    - divide_volume=False时，保持原先不变
    - divide_volume=True时，一级标题为volume里的所有chapter（一些阅读器可以显示 `当前chapter已读的页数 / 当前chapter的总页数`）
