### PR TITLE
feat: Update linovel_mobile volume title

### DIFF
--- a/src/linovelib2epub/spider/linovelib_mobile_spider.py
+++ b/src/linovelib2epub/spider/linovelib_mobile_spider.py
@@ -176,7 +176,11 @@ class LinovelibMobileSpider(BaseNovelWebsiteSpider):
                             soup = BeautifulSoup(page_resp.text, 'lxml')
                         else:
                             raise Exception(f'[ERROR]: request {page_link} failed.')
-
+                        new_title = soup.find(id='atitle')
+                        if not new_title.text.startswith(light_novel_chapter.title):
+                            # 目录页部分文字会被隐藏，所以用文章中的标题代替 new_title 带有分页信息，所以不能==
+                            self.logger.info(f'chapter : [{light_novel_chapter.title}] New Title= [{new_title.text}]')
+                            light_novel_chapter.title = new_title.text
                         images = soup.find_all('img')
                         article_soup = soup.find(id=self._html_content_id)
                         article = _sanitize_html(article_soup)


### PR DESCRIPTION
bili轻小说有[部分小说](https://www.bilinovel.com/novel/2356/catalog)会出现目录里的标题对部分文字做隐藏，所以这里使用文章页里的title做一个覆盖

但是[也有反着来的](https://www.bilinovel.com/novel/2356/83612.html)，但是这种还是比较少见

还有[这种](https://w.linovelib.com/novel/2356/83555.html)里外不一样换法的

![3931037668](https://github.com/lightnovel-center/linovelib2epub/assets/27911304/3b134afb-3e1d-4608-aa5d-b259fedda2ab)
